### PR TITLE
Update difficulty hider to work on all pages

### DIFF
--- a/content.js
+++ b/content.js
@@ -56,8 +56,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 
 function toggleDifficulty(hide) {
-  const difficulties = ["简单", "中等", "困难", "Easy", "Medium", "Hard"];
-  const elements = Array.from(document.querySelectorAll("span, div"));
+  const difficulties = ["简单", "中等", "困难", "Easy", "Medium", "Med.", "Hard"];
+  const elements = Array.from(document.querySelectorAll("span, div, p"));
   
   elements.forEach((el) => {
     if (difficulties.some((difficulty) => el.innerText === difficulty)) {


### PR DESCRIPTION
The current version doesn't hide the difficulty level on some pages (e.g., Lists). So I've made a change to support it.

**List View**
Example page: https://leetcode.com/problem-list/greedy/
![list view screenshot](https://github.com/user-attachments/assets/eb601b56-f895-4969-9b6f-365164ac4e8b)

**Practice History**
https://leetcode.com/progress/
![image](https://github.com/user-attachments/assets/7b1549d5-a472-47d6-be7c-9830a084c283)

