### PR TITLE
Optimized difficulty toggle to work on very long lists (1000+ problems)

### DIFF
--- a/content.js
+++ b/content.js
@@ -59,13 +59,27 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 function toggleDifficulty(hide) {
   const difficulties = ["简单", "中等", "困难", "Easy", "Medium", "Med.", "Hard"];
-  const elements = Array.from(document.querySelectorAll("span, div, p"));
-  
-  elements.forEach((el) => {
-    if (difficulties.some((difficulty) => el.innerText === difficulty)) {
-      el.style.display = hide ? "none" : "";
-    }
-  });
+  const elements = Array
+    .from(document.querySelectorAll("span, div, p"))
+    .filter(el => difficulties.some((difficulty) => el.innerText === difficulty));
+
+  const batchSize = 300;
+  const batches = [];
+  let nextElementIndex = 0;
+
+  while (nextElementIndex < elements.length) {
+    batches.push(elements.slice(nextElementIndex, nextElementIndex + batchSize))
+    nextElementIndex = nextElementIndex + batchSize
+  }
+
+  // Process the elements in batches since some views can have 1000+ elements, which can easily overwhelm the browser
+  batches.forEach((batch, batchIndex) => {
+    setTimeout(() => {
+      batch.forEach(el => {
+        el.style.display = hide ? "none" : ""; 
+      })
+    }, batchIndex * 50);
+  })
 }
 
 function toggleAcceptance(hide) {


### PR DESCRIPTION
This isn't a problem with most lists, but there are some like Google's all time questions list (1700+) problems and (more commonly) the list of all problems on LeetCode (3500+ problems). Basically, the extension would hang when trying to process so many items. With this change, it now takes less than a second or two to process such lists.

The batching implementation works on all pages. But feel free to make any changes if needed.

**Before**
![leetcode hider hang](https://github.com/user-attachments/assets/2ec3eceb-b28b-48b2-a755-1aeb405a0af5)

**After**
![leetcode hider optimized](https://github.com/user-attachments/assets/880c4a96-16da-4b8e-90b8-cbdb6dbf9e3b)
